### PR TITLE
fix everything

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,18 +44,36 @@ RUN python3.8 -m ipykernel install
 
 # Julia
 #############################
-ARG JULIA_VER=1.8.0-rc3
-RUN wget "https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-${JULIA_VER}-linux-x86_64.tar.gz" && \
-    tar -xvzf julia-${JULIA_VER}-linux-x86_64.tar.gz && \
+ARG JULIA_MAJOR=1
+ARG JULIA_MINOR=8
+ARG JULIA_PATCH=0-rc3
+ARG JULIA_VER=$JULIA_MAJOR.$JULIA_MINOR.$JULIA_PATCH
+ENV JULIA_NUM_THREADS auto
+# this is where we install default packages
+ENV JULIA_PKGDIR=/opt/julia
+RUN mkdir /opt/julia-${JULIA_VER} && \
+    wget "https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-${JULIA_VER}-linux-x86_64.tar.gz" && \
+    tar -xvzf julia-${JULIA_VER}-linux-x86_64.tar.gz  -C /opt/julia-${JULIA_VER} --strip-components=1 && \
     rm -rf julia-${JULIA_VER}-linux-x86_64.tar.gz && \
-    ln -s /julia-${JULIA_VER}/bin/julia /usr/local/bin/julia
+    ln -s /opt/julia-${JULIA_VER}/bin/julia /usr/local/bin/julia
 
+RUN mkdir $JULIA_PKGDIR
 # the build step for IJulia should install Jupyter kernal
 RUN export JUPYTER_DATA_DIR=/usr/local/share/jupyter/ && \
-    julia -e 'using Pkg; Pkg.add(["CUDA", "UnROOT", "FHist", "CairoMakie", "IJulia", "PyCall", "ThreadsX", "LorentzVectorHEP", "JSON3", "CSV", "DataFrames", "KernelAbstractions", "Flux", "CUDAKernels"])' && \
-    julia -e 'using Pkg; Pkg.build(["IJulia", "PyCall"])' && \
+    export JULIA_LOAD_PATH="$JULIA_PKGDIR:" && \
+    export JULIA_DEPOT_PATH=$JULIA_PKGDIR && \
+    julia -e 'using Pkg; Pkg.add(["CUDA", "CairoMakie", "PyCall", "KernelAbstractions", "CUDAKernels"])' && \
+    julia -e 'using Pkg; Pkg.add("IJulia")' && \
     julia -e 'using Pkg; Pkg.precompile()'
 
+# setup for end users
+RUN echo 'target = joinpath(homedir(), ".julia", "environments", "v$(string(VERSION)[1:3])")\n\
+if !isfile(joinpath(target, "Project.toml"))\n\
+    mkpath(target)\n\
+    touch(joinpath(target, "Project.toml"))\n\
+end' >> /opt/julia-${JULIA_VER}/etc/julia/startup.jl
+ENV JULIA_LOAD_PATH=":$JULIA_PKGDIR/environments/v$JULIA_MAJOR.$JULIA_MINOR"
+ENV JULIA_DEPOT_PATH=":$JULIA_PKGDIR"
 
 RUN curl -OL https://raw.githubusercontent.com/maniaclab/ci-connect-api/master/resources/provisioner/sync_users_debian.sh
 RUN chmod +x sync_users_debian.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir $JULIA_PKGDIR
 RUN export JUPYTER_DATA_DIR=/usr/local/share/jupyter/ && \
     export JULIA_LOAD_PATH="$JULIA_PKGDIR:" && \
     export JULIA_DEPOT_PATH=$JULIA_PKGDIR && \
-    julia -e 'using Pkg; Pkg.add(["CUDA", "CairoMakie", "PyCall", "KernelAbstractions", "CUDAKernels"])' && \
+    julia -e 'using Pkg; Pkg.add(["CUDA", "PyCall", "KernelAbstractions", "CUDAKernels"])' && \
     julia -e 'using Pkg; Pkg.add("IJulia")' && \
     julia -e 'using Pkg; Pkg.precompile()'
 


### PR DESCRIPTION
last change added kernel spec correctly, this one fix problem where user can't load the correct kernel, I tested the following things, which includes lauching kernel and installing user's own package.

Also, I've reduced the # of pkgs to install so build time should be much faster
```bash
docker run -it julia:test1 bash                                                                (base) 
root@f98b5ed0a358:/$ useradd -m ex
root@f98b5ed0a358:/$ cd /home/ex
root@f98b5ed0a358:/home/ex$ su ex
$ julia

julia> using IJulia

(@v1.8) pkg> add Example
   Resolving package versions...
   Installed Example ─ v0.5.3
    Updating `~/.julia/environments/v1.8/Project.toml`
  [7876af07] + Example v0.5.3
    Updating `~/.julia/environments/v1.8/Manifest.toml`
  [7876af07] + Example v0.5.3
Precompiling project...
  1 dependency successfully precompiled in 1 seconds

julia> notebook()
[ Info: running `/usr/local/bin/jupyter notebook`
```